### PR TITLE
some fixes

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = cvt12-git
 	pkgdesc = Generate mode timings using the CVT v1.2 or CVT v1.1 Timing Standards
-	pkgver = 1.2
+	pkgver = r17.6f66135
 	pkgrel = 1
+	epoch = 1
 	url = https://github.com/kevinlekiller/cvt_modeline_calculator_12
 	arch = i686
 	arch = x86_64
-	license = custom
-	makedepends = gcc>=4.8.0,
+	license = BSD
 	makedepends = git
+	depends = glibc
 	source = git+https://github.com/kevinlekiller/cvt_modeline_calculator_12.git
 	sha256sums = SKIP
 
 pkgname = cvt12-git
-

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,20 +1,28 @@
-
 # Maintainer: Nathan Lowe <techwiz96@gmail.com>
+# Contributor: éclairevoyant
+
 # Upstream URL: https://github.com/kevinlekiller/cvt_modeline_calculator_12
 #
 # For improvements/fixes to this package, please send a pull request:
 # https://github.com/nlowe/aur-cvt12
 
 pkgname=cvt12-git
-pkgver=1.2
+pkgver=r17.6f66135
 pkgrel=1
+epoch=1
 pkgdesc='Generate mode timings using the CVT v1.2 or CVT v1.1 Timing Standards'
 arch=('i686' 'x86_64')
 url='https://github.com/kevinlekiller/cvt_modeline_calculator_12'
-license=('custom')
-makedepends=('gcc>=4.8.0', 'git')
+license=('BSD')
+depends=('glibc')
+makedepends=('git')
 source=("git+${url}.git")
 sha256sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/cvt_modeline_calculator_12"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
 
 build() {
   cd "$srcdir/cvt_modeline_calculator_12"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,7 +18,7 @@ sha256sums=('SKIP')
 
 build() {
   cd $srcdir/cvt_modeline_calculator_12
-  gcc cvt12.c -O2 -o cvt12 -lm -Wall
+  gcc $CFLAGS cvt12.c -O2 -o cvt12 -lm -Wall $LDFLAGS
 }
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -17,15 +17,15 @@ source=("git+${url}.git")
 sha256sums=('SKIP')
 
 build() {
-  cd $srcdir/cvt_modeline_calculator_12
+  cd "$srcdir/cvt_modeline_calculator_12"
   gcc $CFLAGS cvt12.c -O2 -o cvt12 -lm -Wall $LDFLAGS
 }
 
 package() {
   install -Dm755 "$srcdir/cvt_modeline_calculator_12/cvt12" "$pkgdir/usr/bin/cvt12"
 
-  mkdir -p $pkgdir/usr/share/licenses/cvt12
-  cat <<'EOF' >> $pkgdir/usr/share/licenses/cvt12/LICENSE
+  mkdir -p "$pkgdir/usr/share/licenses/cvt12"
+  cat <<'EOF' >> "$pkgdir/usr/share/licenses/cvt12/LICENSE"
 Copyright (c) 2001, Andy Ritger  aritger@nvidia.com
 All rights reserved.
 


### PR DESCRIPTION
This should now pass namcap and follow the current Arch packaging standards. Bumped `epoch` because the `pkgver` is now "less than" the previous version and package versions need to strictly increase.